### PR TITLE
fix(history): Fix pickling issue when response history is non-null

### DIFF
--- a/aiohttp_client_cache/__init__.py
+++ b/aiohttp_client_cache/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 try:
     from aiohttp_client_cache.backends import *  # noqa

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -83,8 +83,8 @@ class CachedResponse:
         response.request_info = RequestInfo.from_object(client_response.request_info)
         response.url = str(client_response.url)
         if client_response.history:
-            response.history = tuple(
-                await cls.from_client_response(r) for r in client_response.history
+            response.history = (
+                *[await cls.from_client_response(r) for r in client_response.history],
             )
         return response
 

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -83,7 +83,9 @@ class CachedResponse:
         response.request_info = RequestInfo.from_object(client_response.request_info)
         response.url = str(client_response.url)
         if client_response.history:
-            response.history = tuple(await cls.from_client_response(r) for r in client_response.history)
+            response.history = tuple(
+                await cls.from_client_response(r) for r in client_response.history
+            )
         return response
 
     @property

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -73,11 +73,17 @@ class CachedResponse:
         # Set some remaining attributes individually
         response._body = client_response._body
         response.headers = dict(client_response.headers)
-        response.encoding = client_response.get_encoding()
+
+        # The encoding may be unset even if the response has been read
+        try:
+            response.encoding = client_response.get_encoding()
+        except RuntimeError:
+            pass
+
         response.request_info = RequestInfo.from_object(client_response.request_info)
         response.url = str(client_response.url)
         if client_response.history:
-            response.history = (cls.from_client_response(r) for r in client_response.history)
+            response.history = tuple(await cls.from_client_response(r) for r in client_response.history)
         return response
 
     @property


### PR DESCRIPTION
Fixes #1.

The main issue was that the response history was being saved as a generator, and that we weren't awaiting the recursive call. This basically caused everything to break when trying to cache a response with any history at all. While fixing this, I also noticed that there are cases where the encoding is null even after the response has been read and released. (In particular, I observed this situation on the actual `ClientResponse` objects that were present in the history itself.) This PR should solve the issue and support caching responses with histories.