### PR TITLE
feat(mongo): Implement contains for mongo cache

### DIFF
--- a/aiohttp_client_cache/backends/mongo.py
+++ b/aiohttp_client_cache/backends/mongo.py
@@ -43,9 +43,8 @@ class MongoDBCache(BaseCache):
     async def clear(self):
         self.collection.drop()
 
-    # TODO
     async def contains(self, key: str) -> bool:
-        raise NotImplementedError
+        return bool(self.collection.find_one({'_id': key}))
 
     async def delete(self, key: str):
         spec = {'_id': key}


### PR DESCRIPTION
Hi, me again :-) just a quick PR to implement `contains` for `MongoDBCache`. Roughly tested it against my own application and all seems to work well.