### PR TITLE
Support case-insensitive response headers for compatibility with aiohttp.ClientResponse.headers

### DIFF
--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -1,13 +1,14 @@
 import json
 from datetime import datetime
 from http.cookies import SimpleCookie
-from typing import Any, Dict, Iterable, Optional, Tuple, Union
+from typing import Any, Dict, Iterable, Optional, Union
 
 import attr
 from aiohttp import ClientResponse, ClientResponseError
-from aiohttp.client_reqrep import ContentDisposition
+from aiohttp.client_reqrep import ContentDisposition, RequestInfo
 from aiohttp.typedefs import RawHeaders, StrOrURL
-from multidict import CIMultiDictProxy, MultiDict
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
 
 # CachedResponse attributes to not copy directly from ClientResponse
 EXCLUDE_ATTRS = {
@@ -16,34 +17,11 @@ EXCLUDE_ATTRS = {
     'encoding',
     'expires',
     'history',
-    'is_expired',
     'last_used',
+    'real_url',
     'request_info',
 }
 JsonResponse = Optional[Dict[str, Any]]
-
-
-@attr.s(auto_attribs=True, slots=True)
-class RequestInfo:
-    """A picklable version of aiohttp.client_reqrep.RequestInfo"""
-
-    url: str
-    method: str
-    real_url: str
-    raw_headers: RawHeaders
-
-    @classmethod
-    def from_object(cls, request_info):
-        return cls(
-            url=str(request_info.url),
-            method=request_info.method,
-            raw_headers=(request_info.raw_headers.items()),
-            real_url=str(request_info.real_url),
-        )
-
-    @property
-    def headers(self) -> CIMultiDictProxy:
-        return decode_headers(self.raw_headers)
 
 
 @attr.s(slots=True)
@@ -65,9 +43,9 @@ class CachedResponse:
     encoding: str = attr.ib(default=None)
     expires: Optional[datetime] = attr.ib(default=None)
     raw_headers: RawHeaders = attr.ib(factory=tuple)
+    real_url: StrOrURL = attr.ib(default=None)
     history: Iterable = attr.ib(factory=tuple)
     last_used: datetime = attr.ib(factory=datetime.utcnow)
-    request_info: RequestInfo = attr.ib(default=None)
 
     @classmethod
     async def from_client_response(cls, client_response: ClientResponse, expires: datetime = None):
@@ -83,6 +61,7 @@ class CachedResponse:
         # Set some remaining attributes individually
         response._body = client_response._body
         response.expires = expires
+        response.real_url = client_response.request_info.real_url
 
         # The encoding may be unset even if the response has been read
         try:
@@ -90,7 +69,6 @@ class CachedResponse:
         except RuntimeError:
             pass
 
-        response.request_info = RequestInfo.from_object(client_response.request_info)
         response.url = str(client_response.url)
         if client_response.history:
             response.history = (
@@ -111,8 +89,16 @@ class CachedResponse:
         return self.encoding
 
     @property
-    def headers(self) -> CIMultiDictProxy:
-        return decode_headers(self.raw_headers)
+    def headers(self) -> CIMultiDictProxy[str]:
+        """Get headers as an immutable, case-insensitive multidict from raw headers"""
+
+        def decode_header(header):
+            return (
+                header[0].decode('utf-8', 'surrogateescape'),
+                header[1].decode('utf-8', 'surrogateescape'),
+            )
+
+        return CIMultiDictProxy(CIMultiDict([decode_header(h) for h in self.raw_headers]))
 
     @property
     def is_expired(self) -> bool:
@@ -121,7 +107,6 @@ class CachedResponse:
 
     async def json(self, encoding: Optional[str] = None, **kwargs) -> Optional[Dict[str, Any]]:
         """Read and decode JSON response"""
-
         stripped = self._body.strip()
         if not stripped:
             return None
@@ -143,22 +128,18 @@ class CachedResponse:
     def release(self):
         """No-op function for compatibility with ClientResponse"""
 
+    @property
+    def request_info(self) -> RequestInfo:
+        return RequestInfo(
+            url=URL(self.url),
+            method=self.method,
+            headers=self.headers,
+            real_url=URL(self.real_url),
+        )
+
     async def text(self, encoding: Optional[str] = None, errors: str = "strict") -> str:
         """Read response payload and decode"""
         return self._body.decode(encoding or self.encoding, errors=errors)
-
-
-def decode_headers(raw_headers: RawHeaders) -> CIMultiDictProxy:
-    """Get an immutable, case-insensitive header dict from raw headers"""
-    return CIMultiDictProxy(MultiDict([decode_header(h) for h in raw_headers]))
-
-
-def decode_header(header: Tuple[bytes, bytes]) -> Tuple[str, str]:
-    """Decode a raw header key-value pair"""
-    return (
-        header[0].decode('utf-8', 'surrogateescape'),
-        header[1].decode('utf-8', 'surrogateescape'),
-    )
 
 
 AnyResponse = Union[ClientResponse, CachedResponse]


### PR DESCRIPTION
Closes #28 

`CachedResponse` now stores raw headers (which are directly serialized), and returns headers as a `CIMultiDictProxy` with a property (which is not serialized). Uses the same decoding as [aiohttp.http_parser.HeadersParser.parse_headers()](https://github.com/aio-libs/aiohttp/blob/64fd941091f1c24b78aa5c2114e389ac2dcdeeb5/aiohttp/http_parser.py#L123-L214).