### PR TITLE
Documentation & CI updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: [main, dev]
   workflow_dispatch:
+env:
+  LATEST_PY_VERSION: '3.9'
 
 jobs:
   test:
@@ -37,42 +39,48 @@ jobs:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('setup.py') }}
           restore-keys: ${{ runner.os }}-pip-${{ matrix.python-version }}
-
       - name: Install dependencies
         run: pip install ".[dev]"
-      - name: Run unit tests
-        run: pytest test/unit
-      - name: Run integration tests
-        run: pytest test/integration
 
+      # Latest python version: Run unit tests with coverage and send to coveralls
+      - name: Run unit tests with code coverage report
+        if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
+        # Run unit tests first to fail quickly if there are issues
+        run: |
+          pytest test/unit --cov --cov-report=term --cov-report=html
+          pytest test/integration --cov --cov-report=term --cov-report=html --cov-append
+      - name: Send code coverage report to Coveralls
+        if: ${{ matrix.python-version == env.LATEST_PY_VERSION }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: coveralls --service=github
+
+      # All other python versions: just run unit tests
+      - name: Run unit tests
+        if: ${{ matrix.python-version != env.LATEST_PY_VERSION }}
+        run: |
+          pytest test/unit
+          pytest test/integration
+
+  # Run code analysis checks
   analyze:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
-
-      # Start integration test databases
-      - uses: supercharge/mongodb-github-action@1.3.0
-        with:
-          mongodb-version: 4.4
-      - uses: supercharge/redis-github-action@1.2.0
-        with:
-          redis-version: '6'
-      # - uses: rrainn/dynamodb-action@v2.0.0
+          python-version: ${{ env.LATEST_PY_VERSION }}
 
       # Cache packages per python version, and reuse until setup.py changes
       - name: Cache pip packages
         uses: actions/cache@v2
         with:
           path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-3.8-${{ hashFiles('setup.py') }}
-          restore-keys: ${{ runner.os }}-pip-3.8
-
-      # Run checks, reports, etc.
+          key: ${{ runner.os }}-pip-${{ env.LATEST_PY_VERSION }}-${{ hashFiles('setup.py') }}
+          restore-keys: ${{ runner.os }}-pip-${{ env.LATEST_PY_VERSION }}
       - name: Install dependencies
         run: pip install ".[dev]"
+
       - name: Run style checks
         run: |
           black --check --diff .
@@ -81,12 +89,6 @@ jobs:
         run: mypy .
       - name: Run linter
         run: flake8 aiohttp_client_cache
-      - name: Generate code coverage report
-        run: pytest test --cov=aiohttp_client_cache --cov-report=term --cov-report=html
-      - name: Send code coverage report to Coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: coveralls --service=github
       - name: Test Sphinx documentation build
         run: make -C docs all
       - name: Test package build
@@ -103,7 +105,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8'
+          python-version: ${{ env.LATEST_PY_VERSION }}
 
       - name: Install dependencies
         run: pip install -U ".[build]"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ sphinx:
   configuration: docs/conf.py
 
 python:
-  version: 3.7
+  version: 3.8
   system_packages: True
   install:
     - method: pip

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-## Installation
+## Dev Installation
 To set up for local development:
 
 ```bash
@@ -49,27 +49,32 @@ $ xdg-open docs/_build/index.html
 ```
 
 ### Readthedocs
-Documentation is automatically built by Readthedocs whenever code is merged into the `main` branch.
+Documentation is automatically built and published by Readthedocs whenever code is merged into the
+`main` branch.
 
 Sometimes, there are differences in the Readthedocs build environment that can cause builds to
-succeed locally but fail remotely. To help debug this, you can use the Readthedocs Docker container
-(`readthedocs/build`) to perform the build. Example:
+succeed locally but fail remotely. To help debug this, you can use the 
+[readthedocs/build](https://github.com/readthedocs/readthedocs-docker-images) container to build
+the docs. A configured build container is included in `docker-compose.yml` to simplify this.
+
+Run with:
 ```bash
-docker pull readthedocs/build
-docker run --rm -ti \
-  -v (pwd):/home/docs/project \
-  readthedocs/build \
-  /bin/bash -c \
-  "cd /home/docs/project \
-    && pip3 install '.[dev]' \
-    && make -C docs html"
+docker-compose up -d --build
+docker exec readthedocs make all
 ```
+
+## Pull Requests
+Here are some general guidelines for submitting a pull request:
+
+- If the changes are trivial, just briefly explain the changes in the PR description.
+- Otherwise, please submit an issue describing the proposed change prior to submitting a PR.
+- Please add unit test coverage and updated docs (if applicable) for your changes.
+- Submit the PR to be merged into the `main` branch.
 
 ## Releases
 Releases are built and published to pypi based on **git tags.**
 [Milestones](https://github.com/JWCook/aiohttp-client-cache/milestones) will be used to track
 progress on major and minor releases.
-
 
 ## Code Layout
 Here is a brief overview of the main classes and modules:

--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ See full documentation at https://aiohttp-client-cache.readthedocs.io
 **This is an early work in progress!**
 
 The current state is a working drop-in replacement (or mixin) for `aiohttp.ClientSession`, with
-multiple asynchronous cache backends.
+multiple asynchronous cache backends. Breaking changes should be expected until a `1.0` release,
+so version pinning is recommended.
 
-Breaking changes should be expected until a `1.0` release.
+I am developing this while also maintaining [requests-cache](https://github.com/reclosedev/requests-cache),
+and my eventual goal is to have a similar (but not identical) feature set between the two libraries.
+If there is a specific feature you want that aiohttp-client-cache doesn't yet have, please create an
+issue to request it!
 
 ## Installation
 Requires python 3.7+
@@ -128,13 +132,13 @@ Other python cache projects you may want to check out:
   file-based cache built on SQLite
 * [aiocache](https://github.com/aio-libs/aiocache): General-purpose (not HTTP-specific) async cache
   backends
-* [requests-cache](https://github.com/reclosedev/requests-cache) An HTTP cache for `requests`; also served as a starting point for making `aiohttp-client-cache`
+* [requests-cache](https://github.com/reclosedev/requests-cache) An HTTP cache for the `requests` library
 * [CacheControl](https://github.com/ionrock/cachecontrol): An HTTP cache for `requests` that caches
   according to uses HTTP headers and status codes
 
 ## Credits
 Thanks to [Roman Haritonov](https://github.com/reclosedev) and
-[contributors](https://github.com/reclosedev/requests-cache/blob/master/CONTRIBUTORS.rst)
+[contributors](https://github.com/reclosedev/requests-cache/blob/master/CONTRIBUTORS.md)
 for the original `requests-cache`!
 
 This project is licensed under the MIT license, with the exception of portions of

--- a/aiohttp_client_cache/backends/base.py
+++ b/aiohttp_client_cache/backends/base.py
@@ -10,6 +10,7 @@ from urllib.parse import parse_qsl, urlparse, urlsplit, urlunparse
 
 from aiohttp import ClientRequest, ClientResponse
 from aiohttp.typedefs import StrOrURL
+from url_normalize import url_normalize
 
 from aiohttp_client_cache.response import AnyResponse, CachedResponse
 
@@ -267,7 +268,7 @@ class CacheBackend:
 
         key = hashlib.sha256()
         key.update(method.upper().encode())
-        key.update(str(url).encode())
+        key.update(str(url_normalize(url)).encode())
         key.update(_encode_dict(params))
         key.update(_encode_dict(data))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,13 @@
 # Containers needed to test all backend services locally
-version: '3'
+version: '3.7'
 
 services:
+  httpbin:
+    image: kennethreitz/httpbin
+    container_name: httpbin
+    ports:
+      - '80:80'
+
   dynamodb:
     image: amazon/dynamodb-local
     hostname: dynamodb-local
@@ -9,12 +15,11 @@ services:
     ports:
       - 8000:8000
     command: '-jar DynamoDBLocal.jar -inMemory'
-    # volumes:
-    #   - 'dynamodb_data:/home/dynamodblocal/data'
     working_dir: /home/dynamodblocal
 
   mongo:
     image: mongo
+    container_name: mongo
     environment:
       MONGO_INITDB_DATABASE: aiohttp_client_cache_pytest
     ports:
@@ -24,17 +29,15 @@ services:
 
   redis:
     image: docker.io/bitnami/redis
+    container_name: redis
     environment:
       ALLOW_EMPTY_PASSWORD: 'yes'
-      # REDIS_DISABLE_COMMANDS: 'FLUSHDB,FLUSHALL'
     ports:
       - 6379:6379
     volumes:
       - 'redis_data:/bitnami/redis/data'
 
 volumes:
-  dynamodb_data:
-    driver: local
   mongodb_data:
     driver: local
   redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,18 @@ services:
     volumes:
       - 'redis_data:/bitnami/redis/data'
 
+  readthedocs:
+    container_name: readthedocs
+    build:
+      context: .
+      dockerfile: docs/Dockerfile
+      network: host
+    user: '1000'
+    tty: true
+    volumes:
+      - '.:/home/docs/project'
+    working_dir: '/home/docs/project/docs'
+
 volumes:
   mongodb_data:
     driver: local

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,5 @@
+# Readthedocs build container with project dependencies pre-installed
+FROM readthedocs/build:8.0
+COPY . /src/
+RUN pip3 install -U /src/[docs,backends]
+ENTRYPOINT ["/bin/bash"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,6 +30,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
     'sphinx_autodoc_typehints',
+    'sphinx_copybutton',
     'sphinxcontrib.apidoc',
     'm2r2',
 ]
@@ -50,8 +51,11 @@ napoleon_include_private_with_doc = False
 napoleon_include_special_with_doc = False
 numpydoc_show_class_members = False
 
+# Strip prompt text when copying code blocks with copy button
+copybutton_prompt_text = r'>>> |\.\.\. |\$ '
+copybutton_prompt_is_regexp = True
+
 # Use apidoc to auto-generate rst sources
-# Added here instead of instead of in Makefile so it will be used by ReadTheDocs
 apidoc_excluded_paths = ['api_docs.py']
 apidoc_extra_args = ['--private']
 apidoc_module_dir = PACKAGE_DIR

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,4 +72,13 @@ set_type_checking_flag = True
 
 # HTML theme settings
 pygments_style = 'sphinx'
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'sphinx_material'
+html_theme_options = {
+    'color_primary': 'blue',
+    'color_accent': 'light-blue',
+    'logo_icon': '&#xe1af',
+    'repo_url': 'https://github.com/reclosedev/requests-cache',
+    'repo_name': project,
+    'nav_title': project,
+}
+html_sidebars = {'**': ['logo-text.html', 'globaltoc.html', 'localtoc.html', 'searchbox.html']}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,10 +2,10 @@
 
 .. Omit README link to ReadTheDocs, since we're already on ReadTheDocs!
 .. mdinclude:: ../README.md
-    :end-line: 9
+    :end-line: 15
 
 .. mdinclude:: ../README.md
-    :start-line: 11
+    :start-line: 17
 
 
 Contents

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ extras_require = {
         'Sphinx~=3.5.3',
         'sphinx-autodoc-typehints',
         'sphinx-copybutton',
-        'sphinx-rtd-theme~=0.5.2',
+        'sphinx-material',
         'sphinxcontrib-apidoc',
     ],
     # Packages used for testing both locally and in CI jobs

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,12 @@ extras_require = {
     'backends': ['aiosqlite', 'boto3', 'motor', 'aioredis'],
     # Packages used for documentation builds
     'docs': [
-        'm2r2',
-        'Sphinx~=3.2.1',
+        'm2r2~=0.2.5',
+        'docutils==0.16',
+        'Sphinx~=3.5.3',
         'sphinx-autodoc-typehints',
-        'sphinx-rtd-theme',
+        'sphinx-copybutton',
+        'sphinx-rtd-theme~=0.5.2',
         'sphinxcontrib-apidoc',
     ],
     # Packages used for testing both locally and in CI jobs

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     version=__version__,
-    install_requires=['aiohttp', 'attrs', 'python-forge'],
+    install_requires=['aiohttp', 'attrs', 'python-forge', 'url-normalize'],
     extras_require=extras_require,
     zip_safe=False,
 )


### PR DESCRIPTION
* Update dependencies due to changes in docutils
* Switch docs to Material theme
* Use url-normalize to normalize URLs when creating cache keys
* Add some more details to Readme and Contributing Guide
* Update CI config to combine test coverage reports with other tests, so we don't need to spin up integration test databases for multiple jobs
* Add docker-compose config for httpbin
* And add docker-compose config for readthedocs build environment
