### PR TITLE
fix: short circuit get_response when no resp found

### DIFF
--- a/aiohttp_client_cache/backends/base.py
+++ b/aiohttp_client_cache/backends/base.py
@@ -179,6 +179,7 @@ class CacheBackend:
 
         if not response:
             logger.debug('No cached response found')
+            return None
 
         # If the item is expired or filtered out, delete it from the cache
         if not self.is_cacheable(response):


### PR DESCRIPTION
Sorry, I neglected to return here but had meant to. Without this, there's a misleading "Cached response expired" log message, and an unnecessary call to delete.