### PR TITLE
Add support for per-request expiration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,7 @@ progress on major and minor releases.
 Here is a brief overview of the main classes and modules:
 * `session.CacheMixin`, `session.CachedSession`: A mixin and wrapper class, respectively, for `aiohttp.ClientSession`. There is little logic  here except wrapping `ClientSession._request()` with caching behavior.
 * `response.CachedResponse`: A wrapper class built from an `aiohttp.ClientResponse`, with additional cache-related info. This is what is serialized and persisted to the cache.
-* `backends.base.CacheBackend`: Most of the caching logic lives here, including saving and retriving responses, creating cache keys, expiration, etc. It contains two `BaseCache` objects for storing responses and redirects, respectively. By default this is just a non-persistent dict cache.
+* `backends.base.CacheBackend`: Most of the caching logic lives here, including saving and retriving responses. It contains two `BaseCache` objects for storing responses and redirects, respectively.
+* `cache_keys` and `expiration`: Utilities for creating cache keys and cache expiration, respectively
 * `backends.base.BaseCache`: Base class for lower-level storage operations, overridden by individual backends.
 * Other backend implementations in `backends.*`: A backend implementation subclasses `CacheBackend` (for higher-level operations), as well as `BaseCache` (for lower-level operations).

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,7 +4,8 @@
 [See all issues & PRs here](https://github.com/JWCook/aiohttp-client-cache/milestone/2?closed=1)
 
 * Add async implementation of DynamoDb backend
-* Add support for setting different expiration times based on URL patterns
+* Add support for expiration for individual requests
+* Add support for expiration based on URL patterns
 * Add support for serializing/deserializing `ClientSession.links`
 * Add case-insensitive response headers for compatibility with aiohttp.ClientResponse.headers
 * Add optional integration with `itsdangerous` for safer serialization

--- a/aiohttp_client_cache/backends/mongo.py
+++ b/aiohttp_client_cache/backends/mongo.py
@@ -21,7 +21,7 @@ class MongoDBBackend(CacheBackend):
     ):
         super().__init__(cache_name=cache_name, **kwargs)
         self.responses = MongoDBPickleCache(cache_name, 'responses', connection, **kwargs)
-        self.keys_map = MongoDBCache(cache_name, 'redirects', self.responses.connection, **kwargs)
+        self.redirects = MongoDBCache(cache_name, 'redirects', self.responses.connection, **kwargs)
 
 
 class MongoDBCache(BaseCache):

--- a/aiohttp_client_cache/cache_keys.py
+++ b/aiohttp_client_cache/cache_keys.py
@@ -1,3 +1,4 @@
+"""Functions for creating keys used for cache requests"""
 import hashlib
 from collections.abc import Mapping
 from typing import Dict, List
@@ -41,7 +42,8 @@ def create_key(
 
 
 def filter_ignored_params(data, ignored_params):
-    if not isinstance(data, Mapping):
+    """Remove any ignored params from an object, if it's dict-like"""
+    if not isinstance(data, Mapping) or not ignored_params:
         return data
     return {k: v for k, v in data.items() if k not in ignored_params}
 

--- a/aiohttp_client_cache/expiration.py
+++ b/aiohttp_client_cache/expiration.py
@@ -1,0 +1,79 @@
+"""Functions for determining cache expiration"""
+from datetime import datetime, timedelta
+from fnmatch import fnmatch
+from logging import getLogger
+from typing import Dict, Optional, Union
+
+from aiohttp import ClientResponse
+from aiohttp.typedefs import StrOrURL
+
+ExpirationTime = Union[None, int, float, datetime, timedelta]
+ExpirationPatterns = Dict[str, ExpirationTime]
+logger = getLogger(__name__)
+
+
+def get_expiration(
+    response: ClientResponse,
+    request_expire_after: ExpirationTime = None,
+    session_expire_after: ExpirationTime = None,
+    urls_expire_after: ExpirationPatterns = None,
+) -> Optional[datetime]:
+    """Get the appropriate expiration for the given response, in order of precedence:
+    1. Per-request expiration
+    2. Per-URL expiration
+    3. Per-session expiration
+
+    Returns:
+        An absolute expiration :py:class:`.datetime` or ``None``
+    """
+    return get_expiration_datetime(
+        request_expire_after
+        or get_expiration_for_url(response.url, urls_expire_after)
+        or session_expire_after
+    )
+
+
+def get_expiration_datetime(expire_after: ExpirationTime) -> Optional[datetime]:
+    """Convert a relative time value or delta to an absolute datetime, if it's not already"""
+    logger.debug(f'Determining expiration time based on: {expire_after}')
+    if expire_after is None or expire_after == -1:
+        return None
+    elif isinstance(expire_after, datetime):
+        return expire_after
+
+    if not isinstance(expire_after, timedelta):
+        expire_after = timedelta(seconds=expire_after)
+    return datetime.utcnow() + expire_after
+
+
+def get_expiration_for_url(
+    url: StrOrURL, urls_expire_after: ExpirationPatterns = None
+) -> ExpirationTime:
+    """Check for a matching per-URL expiration, if any"""
+    for pattern, expire_after in (urls_expire_after or {}).items():
+        if url_match(url, pattern):
+            logger.debug(f'URL {url} matched pattern "{pattern}": {expire_after}')
+            return expire_after
+    return None
+
+
+def url_match(url: StrOrURL, pattern: str) -> bool:
+    """Determine if a URL matches a pattern
+
+    Args:
+        url: URL to test. Its base URL (without protocol) will be used.
+        pattern: Glob pattern to match against. A recursive wildcard will be added if not present
+
+    Example:
+        >>> url_match('https://httpbin.org/delay/1', 'httpbin.org/delay')
+        True
+        >>> url_match('https://httpbin.org/stream/1', 'httpbin.org/*/1')
+        True
+        >>> url_match('https://httpbin.org/stream/2', 'httpbin.org/*/1')
+        False
+    """
+    if not url:
+        return False
+    url = str(url).split('://')[-1]
+    pattern = pattern.split('://')[-1].rstrip('*') + '**'
+    return fnmatch(url, pattern)

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 from http.cookies import SimpleCookie
+from logging import getLogger
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple, Union
 
 import attr
@@ -26,6 +27,8 @@ JsonResponse = Optional[Dict[str, Any]]
 DictItems = List[Tuple[str, str]]
 LinkItems = List[Tuple[str, DictItems]]
 LinkMultiDict = MultiDictProxy[MultiDictProxy[Union[str, URL]]]
+
+logger = getLogger(__name__)
 
 
 @attr.s(slots=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ directory = 'test-reports'
 [tool.coverage.run]
 branch = true
 source = ['aiohttp_client_cache']
+omit = ['aiohttp_client_cache/backends/__init__.py']
 
 [tool.isort]
 profile = "black"

--- a/test/integration/test_cache.py
+++ b/test/integration/test_cache.py
@@ -25,7 +25,6 @@ async def test_all_methods(field, method, tempfile_session):
         assert not from_cache(response_1) and from_cache(response_2)
 
 
-# TODO: Fix ignored parameters for data, json
 @pytest.mark.parametrize('method', HTTPBIN_METHODS)
 @pytest.mark.parametrize('field', ['params', 'data', 'json'])
 async def test_all_methods__ignore_parameters(field, method, tempfile_session):
@@ -56,6 +55,15 @@ async def test_redirects(endpoint, n_redirects, tempfile_session):
     await tempfile_session.get(httpbin('get'))
 
     assert await tempfile_session.cache.redirects.size() == n_redirects
+
+
+async def test_include_headers(tempfile_session):
+    tempfile_session.cache.include_headers = True
+    await tempfile_session.get(httpbin('get'))
+    response_1 = await tempfile_session.get(httpbin('get'), headers={'key': 'value'})
+    response_2 = await tempfile_session.get(httpbin('get'), headers={'key': 'value'})
+
+    assert not from_cache(response_1) and from_cache(response_2)
 
 
 async def test_serializer_pickle():

--- a/test/integration/test_mongo_backend.py
+++ b/test/integration/test_mongo_backend.py
@@ -5,7 +5,7 @@ from motor.motor_asyncio import AsyncIOMotorClient
 from pymongo import MongoClient
 from pymongo.errors import ConnectionFailure
 
-from aiohttp_client_cache.backends.mongo import MongoDBCache
+from aiohttp_client_cache.backends.mongo import MongoDBBackend, MongoDBCache
 
 
 def is_db_running():
@@ -31,6 +31,11 @@ async def cache_client():
     await cache_client.clear()
     yield cache_client
     await cache_client.clear()
+
+
+def test_backend_init():
+    backend = MongoDBBackend('aiohttp-cache')
+    assert backend.responses.connection == backend.redirects.connection
 
 
 async def test_clear(cache_client):

--- a/test/integration/test_redis_backend.py
+++ b/test/integration/test_redis_backend.py
@@ -38,7 +38,7 @@ async def cache_client():
     await cache_client.clear()
 
 
-def test_redis_backend():
+def test_backend_init():
     backend = RedisBackend()
     assert backend.responses.address == DEFAULT_ADDRESS
     assert backend.responses.hash_key == 'aiohttp-cache:responses'

--- a/test/unit/test_expiration.py
+++ b/test/unit/test_expiration.py
@@ -1,0 +1,64 @@
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from aiohttp_client_cache.expiration import get_expiration, get_expiration_datetime
+
+
+@pytest.mark.parametrize(
+    'url, request_expire_after, expected_expiration',
+    [
+        ('img.site_1.com', None, timedelta(hours=12)),
+        ('img.site_1.com', 60, 60),
+        ('http://img.site.com/base/', None, 1),
+        ('https://img.site.com/base/img.jpg', None, 1),
+        ('site_2.com/resource_1', None, timedelta(hours=20)),
+        ('http://site_2.com/resource_1/index.html', None, timedelta(hours=20)),
+        ('http://site_2.com/resource_2/', None, timedelta(days=7)),
+        ('http://site_2.com/static/', None, -1),
+        ('http://site_2.com/static/img.jpg', None, -1),
+        ('site_2.com', None, 1),
+        ('site_2.com', 60, 60),
+        ('some_other_site.com', None, 1),
+        ('some_other_site.com', 60, 60),
+    ],
+)
+@patch('aiohttp_client_cache.expiration.get_expiration_datetime', side_effect=lambda x: x)
+def test_get_expiration(
+    mock_get_expiration_datetime, url, request_expire_after, expected_expiration
+):
+    """Test expiration precedence and URL patterns for get_expiration.
+    Mocking out datetime conversion to test in a separate test function.
+    """
+    session_expire_after = 1
+    urls_expire_after = {
+        '*.site_1.com': timedelta(hours=12),
+        'site_2.com/resource_1': timedelta(hours=20),
+        'site_2.com/resource_2': timedelta(days=7),
+        'site_2.com/static': -1,
+    }
+    expiration = get_expiration(
+        MagicMock(url=url), request_expire_after, session_expire_after, urls_expire_after
+    )
+    assert expiration == expected_expiration
+
+
+def test_get_expiration_datetime__no_expiration():
+    assert get_expiration_datetime(None) is None
+    assert get_expiration_datetime(-1) is None
+
+
+@pytest.mark.parametrize(
+    'expire_after, expected_expiration_delta',
+    [
+        (datetime.utcnow(), timedelta(seconds=0)),
+        (timedelta(seconds=60), timedelta(seconds=60)),
+        (60, timedelta(seconds=60)),
+        (33.3, timedelta(seconds=33.3)),
+    ],
+)
+def test_get_expiration_datetime__relative(expire_after, expected_expiration_delta):
+    expires = get_expiration_datetime(expire_after)
+    expected_expiration = datetime.utcnow() + expected_expiration_delta
+    # Instead of mocking datetime (which adds some complications), check for approximate value
+    assert abs((expires - expected_expiration).total_seconds()) <= 5

--- a/test/unit/test_response.py
+++ b/test/unit/test_response.py
@@ -41,14 +41,15 @@ async def test_basic_attrs(aiohttp_client):
     assert response.headers['Content-Type'] == 'text/plain; charset=utf-8'
     assert await response.text() == '404: Not Found'
     assert response.history == tuple()
+
+
+async def test_is_expired(aiohttp_client):
+    expires = datetime.utcnow() + timedelta(seconds=0.02)
+    response = await get_test_response(aiohttp_client, expires=expires)
+
+    assert response.expires == expires
     assert response.is_expired is False
-
-
-async def test_expiration(aiohttp_client):
-    response = await get_test_response(
-        aiohttp_client, expires=datetime.utcnow() + timedelta(seconds=0.01)
-    )
-    await asyncio.sleep(0.01)
+    await asyncio.sleep(0.02)
     assert response.is_expired is True
 
 


### PR DESCRIPTION
Closes #45 , and does some of the prep work needed for #30 and #32.

Other changes:
* Move all expiration logic into a separate module, and add more tests
* If `expire_after` is numeric, expect in in seconds instead of hours (for consistency with Cache-Control)
* Add some more unit test coverage for CacheBackend