### PR TITLE
Refactor utilities for resolving expiration settings + headers into a separate class

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,10 +77,11 @@ Releases are built and published to pypi based on **git tags.**
 progress on major and minor releases.
 
 ## Code Layout
-Here is a brief overview of the main classes and modules:
+Here is a brief overview of the main classes and modules. See [API Reference](https://aiohttp-client-cache.readthedocs.io/en/latest/reference.html) for more complete documentation.
 * `session.CacheMixin`, `session.CachedSession`: A mixin and wrapper class, respectively, for `aiohttp.ClientSession`. There is little logic  here except wrapping `ClientSession._request()` with caching behavior.
 * `response.CachedResponse`: A wrapper class built from an `aiohttp.ClientResponse`, with additional cache-related info. This is what is serialized and persisted to the cache.
-* `backends.base.CacheBackend`: Most of the caching logic lives here, including saving and retriving responses. It contains two `BaseCache` objects for storing responses and redirects, respectively.
-* `cache_keys` and `expiration`: Utilities for creating cache keys and cache expiration, respectively
+* `backends.base.CacheBackend`: Most of the caching logic lives here, including saving and retrieving responses. It contains two `BaseCache` objects for storing responses and redirects, respectively.
 * `backends.base.BaseCache`: Base class for lower-level storage operations, overridden by individual backends.
-* Other backend implementations in `backends.*`: A backend implementation subclasses `CacheBackend` (for higher-level operations), as well as `BaseCache` (for lower-level operations).
+* Other modules under `backends.*`: Backend implementations that subclass `CacheBackend` + `BaseCache`
+* `cache_control`: Utilities for determining cache expiration and other cache actions  
+* `cache_keys`: Utilities for creating cache keys

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,15 @@
 # History
 
 ## 0.4.0 (2021-TBD)
-* Add optional support for `Cache-Control: max-age` and `no-store` response headers
+* Add optional support for the following **request** headers:
+    * `Cache-Control: max-age`
+    * `Cache-Control: no-cache`
+    * `Cache-Control: no-store`
+* Add optional support for the following **response** headers:
+    * `Cache-Control: max-age`
+    * `Cache-Control: no-store`
+    * `Expires`
+* Add support for HTTP timestamps (RFC 5322) in ``expire_after`` parameters
 
 
 ## 0.3.0 (2021-04-09)

--- a/aiohttp_client_cache/backends/base.py
+++ b/aiohttp_client_cache/backends/base.py
@@ -2,18 +2,12 @@ import pickle
 from abc import ABCMeta, abstractmethod
 from collections import UserDict
 from logging import getLogger
-from typing import AsyncIterable, Callable, Iterable, Optional, Union
+from typing import AsyncIterable, Callable, Iterable, Optional, Tuple, Union
 
 from aiohttp import ClientResponse
 from aiohttp.typedefs import StrOrURL
 
-from aiohttp_client_cache.cache_control import (
-    DO_NOT_CACHE,
-    ExpirationPatterns,
-    ExpirationTime,
-    get_expiration,
-    get_expiration_datetime,
-)
+from aiohttp_client_cache.cache_control import CacheActions, ExpirationPatterns, ExpirationTime
 from aiohttp_client_cache.cache_keys import create_key
 from aiohttp_client_cache.docs.forge_utils import extend_init_signature
 from aiohttp_client_cache.response import AnyResponse, CachedResponse
@@ -92,14 +86,32 @@ class CacheBackend:
         logger.debug(f'Pre-cache checks for response from {response.url}: {cache_criteria}')  # type: ignore
         return all(cache_criteria.values())
 
-    async def get_response(self, key: str) -> Optional[CachedResponse]:
-        """Retrieve response and timestamp for `key` if it's stored in cache,
-        otherwise returns ``None```
+    async def request(
+        self,
+        method: str = None,
+        url: StrOrURL = None,
+        expire_after: ExpirationTime = None,
+        **kwargs,
+    ) -> Tuple[Optional[CachedResponse], CacheActions]:
+        """Fetch a cached response based on request info"""
+        key = self.create_key(method, url, **kwargs)
+        actions = CacheActions.from_request(
+            key,
+            url=url,
+            request_expire_after=expire_after,
+            session_expire_after=self.expire_after,
+            urls_expire_after=self.urls_expire_after,
+            cache_control=self.cache_control,
+            **kwargs,
+        )
 
-        Args:
-            key: key of resource
-        """
-        # Attempt to fetch response from the cache
+        # Skip reading from the cache, if specified by request headers
+        response = None if actions.skip_read else await self.get_response(actions.key)
+        return response, actions
+
+    async def get_response(self, key: str) -> Optional[CachedResponse]:
+        """Fetch a cached response based on a cache key"""
+        # Attempt to fetch the cached response
         logger.debug(f'Attempting to get cached response for key: {key}')
         try:
             response = await self.responses.read(key) or await self._get_redirect_response(str(key))
@@ -125,41 +137,30 @@ class CacheBackend:
         return await self.responses.read(redirect_key) if redirect_key else None  # type: ignore
 
     async def save_response(
-        self, key: str, response: ClientResponse, expire_after: ExpirationTime = None
+        self,
+        response: ClientResponse,
+        actions: CacheActions,
     ):
         """Save response to cache
 
         Args:
-            key: Key for this response
             response: Response to save
+            actions: Specific cache actions to take
             expire_after: Expiration time to set only for this request; overrides
                 ``CachedSession.expire_after``, and accepts all the same values.
         """
-        expire_after = self.get_expiration(response, expire_after)
-        if not self.is_cacheable(response) or expire_after == DO_NOT_CACHE:
-            logger.debug(f'Not caching response for key: {key}')
+        actions.update_from_response(response)
+        if not self.is_cacheable(response) or actions.skip_write:
+            logger.debug(f'Not caching response for key: {actions.key}')
             return
 
-        logger.debug(f'Saving response for key: {key}')
-        expire_after = get_expiration_datetime(expire_after)
-        cached_response = await CachedResponse.from_client_response(response, expire_after)
-        await self.responses.write(key, cached_response)
+        logger.debug(f'Saving response for key: {actions.key}')
+        cached_response = await CachedResponse.from_client_response(response, actions.expires)
+        await self.responses.write(actions.key, cached_response)
 
         # Alias any redirect requests to the same cache key
         for r in response.history:
-            await self.redirects.write(self.create_key(r.method, r.url), key)
-
-    def get_expiration(
-        self, response: ClientResponse, request_expire_after: ExpirationTime = None
-    ) -> ExpirationTime:
-        """Get the appropriate expiration for the given response"""
-        return get_expiration(
-            response,
-            request_expire_after,
-            self.expire_after,
-            self.urls_expire_after,
-            self.cache_control,
-        )
+            await self.redirects.write(self.create_key(r.method, r.url), actions.key)
 
     async def clear(self):
         """Clear cache"""

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -27,5 +27,5 @@ Utility Modules
 .. toctree::
     :titlesonly:
 
+    modules/aiohttp_client_cache.cache_control.rst
     modules/aiohttp_client_cache.cache_keys.rst
-    modules/aiohttp_client_cache.expiration.rst

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 from logging import basicConfig, getLogger
 from os import getenv
 from tempfile import NamedTemporaryFile
@@ -24,6 +25,9 @@ HTTPBIN_FORMATS = [
     'robots.txt',
     'xml',
 ]
+
+HTTPDATE_STR = 'Fri, 16 APR 2021 21:13:00 GMT'
+HTTPDATE_DATETIME = datetime(2021, 4, 16, 21, 13, tzinfo=timezone.utc)
 
 
 # Configure logging for pytest session
@@ -56,3 +60,9 @@ async def get_tempfile_session(**kwargs) -> AsyncIterator[CachedSession]:
         cache = SQLiteBackend(cache_name=temp.name, allowed_methods=ALL_METHODS, **kwargs)
         async with CachedSession(cache=cache) as session:
             yield session
+
+
+def assert_delta_approx_equal(dt1: datetime, dt2: datetime, target_delta, threshold_seconds=2):
+    """Assert that the given datetimes are approximately ``target_delta`` seconds apart"""
+    diff_in_seconds = (dt2 - dt1).total_seconds()
+    assert abs(diff_in_seconds - target_delta) <= threshold_seconds

--- a/test/integration/test_cache.py
+++ b/test/integration/test_cache.py
@@ -8,7 +8,16 @@ from itsdangerous.exc import BadSignature
 from itsdangerous.serializer import Serializer
 
 from aiohttp_client_cache import CachedSession, SQLiteBackend
-from test.conftest import HTTPBIN_METHODS, from_cache, get_tempfile_session, httpbin
+from aiohttp_client_cache.cache_control import to_utc
+from test.conftest import (
+    HTTPBIN_METHODS,
+    HTTPDATE_DATETIME,
+    HTTPDATE_STR,
+    assert_delta_approx_equal,
+    from_cache,
+    get_tempfile_session,
+    httpbin,
+)
 
 pytestmark = [pytest.mark.asyncio]
 
@@ -67,14 +76,65 @@ async def test_include_headers(tempfile_session):
     assert not from_cache(response_1) and from_cache(response_2)
 
 
-async def test_cache_control(tempfile_session):
+@pytest.mark.parametrize(
+    'request_headers, expected_expiration',
+    [
+        ({}, 60),
+        ({'Cache-Control': 'max-age=360'}, 360),
+        ({'Cache-Control': 'no-store'}, None),
+        ({'Expires': HTTPDATE_STR, 'Cache-Control': 'max-age=360'}, 360),
+    ],
+)
+async def test_cache_control_expiration(request_headers, expected_expiration, tempfile_session):
+    """Test cache headers for both requests and responses. The `/cache/{seconds}` endpoint returns
+    Cache-Control headers, which should be used unless request headers are sent.
+    """
     tempfile_session.cache.cache_control = True
     now = datetime.utcnow()
-    await tempfile_session.get(httpbin('cache/60'))
-    response = await tempfile_session.get(httpbin('cache/60'))
+    await tempfile_session.get(httpbin('cache/60'), headers=request_headers)
+    response = await tempfile_session.get(httpbin('cache/60'), headers=request_headers)
 
-    approx_expire_after = (response.expires - now).total_seconds()
-    assert abs(approx_expire_after - 60) <= 2
+    if expected_expiration is None:
+        assert response.expires is None
+    else:
+        assert_delta_approx_equal(now, response.expires, expected_expiration)
+
+
+async def test_request_skip_cache_read(tempfile_session):
+    """no-cache request header should skip reading, but still write to the cache"""
+    tempfile_session.cache.cache_control = True
+    headers = {'Cache-Control': 'no-cache'}
+    await tempfile_session.get(httpbin('get'), headers=headers)
+    response = await tempfile_session.get(httpbin('get'), headers=headers)
+
+    assert response.from_cache is False
+    assert await tempfile_session.cache.responses.size() == 1
+    assert (await tempfile_session.get(httpbin('get'))).from_cache is True
+
+
+@pytest.mark.parametrize('directive', ['max-age=0', 'no-store'])
+async def test_request_skip_cache_read_write(directive, tempfile_session):
+    """max-age=0 and no-store request headers should skip both reading from and writing to the cache"""
+    tempfile_session.cache.cache_control = True
+    headers = {'Cache-Control': directive}
+    await tempfile_session.get(httpbin('get'), headers=headers)
+    response = await tempfile_session.get(httpbin('get'), headers=headers)
+
+    assert response.from_cache is False
+    assert await tempfile_session.cache.responses.size() == 0
+
+    await tempfile_session.get(httpbin('get'))
+    assert (await tempfile_session.get(httpbin('get'))).from_cache is True
+
+
+async def test_response_skip_cache_write(tempfile_session):
+    """max-age=0 response header should skip writing to the cache"""
+    tempfile_session.cache.cache_control = True
+    await tempfile_session.get(httpbin('cache/0'))
+    response = await tempfile_session.get(httpbin('cache/0'))
+
+    assert response.from_cache is False
+    assert await tempfile_session.cache.responses.size() == 0
 
 
 async def test_serializer_pickle():

--- a/test/unit/test_response.py
+++ b/test/unit/test_response.py
@@ -49,6 +49,7 @@ async def test_basic_attrs(aiohttp_client):
     assert response.headers['Content-Type'] == 'text/plain; charset=utf-8'
     assert await response.text() == '404: Not Found'
     assert response.history == tuple()
+    assert response._released is True
 
 
 async def test_is_expired(aiohttp_client):

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from aiohttp_client_cache.backends import CacheBackend
+from aiohttp_client_cache.cache_control import CacheActions
 from aiohttp_client_cache.session import CachedSession, ClientSession
 
 pytestmark = [pytest.mark.asyncio]
@@ -16,7 +17,7 @@ except ImportError:
 @patch.object(ClientSession, '_request')
 async def test_session__cache_hit(mock_request):
     cache = MagicMock(spec=CacheBackend)
-    cache.get_response.return_value = AsyncMock(is_expired=False)
+    cache.request.return_value = AsyncMock(is_expired=False), CacheActions()
     session = CachedSession(cache=cache)
 
     await session.get('http://test.url')
@@ -26,7 +27,7 @@ async def test_session__cache_hit(mock_request):
 @patch.object(ClientSession, '_request')
 async def test_session__cache_expired_or_invalid(mock_request):
     cache = MagicMock(spec=CacheBackend)
-    cache.get_response.return_value = None
+    cache.request.return_value = None, CacheActions()
     session = CachedSession(cache=cache)
 
     await session.get('http://test.url')
@@ -36,7 +37,7 @@ async def test_session__cache_expired_or_invalid(mock_request):
 @patch.object(ClientSession, '_request')
 async def test_session__cache_miss(mock_request):
     cache = MagicMock(spec=CacheBackend)
-    cache.get_response.return_value = None
+    cache.request.return_value = None, CacheActions()
     session = CachedSession(cache=cache)
 
     await session.get('http://test.url')
@@ -46,7 +47,7 @@ async def test_session__cache_miss(mock_request):
 @patch.object(ClientSession, '_request')
 async def test_session__default_attrs(mock_request):
     cache = MagicMock(spec=CacheBackend)
-    cache.get_response.return_value = None
+    cache.request.return_value = None, CacheActions()
     session = CachedSession(cache=cache)
 
     response = await session.get('http://test.url')


### PR DESCRIPTION
Updates #30, closes #58, and makes handling request headers possible for #32. 

The class will be responsible for translating CacheBackend settings and request + response headers into specific actions to take for a given cache item. This will be convenient for reducing shared logic between request and response headers, and reducing arguments passed between functions (mainly between `get_reponse()` and `save_response()`).

I was originally just going to do some refactoring, but at this point the following items were pretty trivial so I went ahead and added them:

* Add support for `max-age`, `no-cache`, and `no-store` request headers
* Add support for `Expires` response header