### PR TITLE
Fix looping over streaming responses with readany()

### DIFF
--- a/test/integration/base_backend_test.py
+++ b/test/integration/base_backend_test.py
@@ -99,13 +99,23 @@ class BaseBackendTest:
                 lines = [line async for line in response.content]
                 assert len(b''.join(lines)) == 64
 
-            # Test some additional methods on the cached response (which can be re-read)
+            # Test some additional methods on the cached response
+            response.reset()
             chunks = [c async for (c, _) in response.content.iter_chunks()]
             assert len(b''.join(chunks)) == 64
+            response.reset()
+
             chunks = [c async for c in response.content.iter_chunked(2)]
             assert len(b''.join(chunks)) == 64
+            response.reset()
+
             chunks = [c async for c in response.content.iter_any()]
             assert len(b''.join(chunks)) == 64
+            response.reset()
+
+            # readany() should return empty bytes after being consumed
+            assert len(await response.content.readany()) == 64
+            assert await response.content.readany() == b''
 
     @pytest.mark.parametrize(
         'request_headers, expected_expiration',


### PR DESCRIPTION
Updates #89 