### PR TITLE
Add support for cached session cookies

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 # 0.6.0 (Unreleased)
 * Add a `bulk_delete()` method for all backends to improve performance of `delete_expired_responses()`
+* Update session cookies after fetching cached responses with cookies
 
 ## 0.5.2 (2021-11-03)
 * Fix compatibility with aiohttp 3.8

--- a/aiohttp_client_cache/session.py
+++ b/aiohttp_client_cache/session.py
@@ -42,6 +42,9 @@ class CacheMixin(MIXIN_BASE):
         # Attempt to fetch cached response; if missing or expired, fetch new one
         response, actions = await self.cache.request(method, str_or_url, **kwargs)
         if response:
+            self._cookie_jar.update_cookies(response.cookies, response.url)
+            for redirect in response.history:
+                self._cookie_jar.update_cookies(redirect.cookies, redirect.url)
             return response
         else:
             logger.debug(f'Cached response not found; making request to {str_or_url}')

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -38,7 +38,8 @@ async def test_session__init_posarg():
 @patch.object(ClientSession, '_request')
 async def test_session__cache_hit(mock_request):
     cache = MagicMock(spec=CacheBackend)
-    cache.request.return_value = AsyncMock(is_expired=False), CacheActions()
+    response = AsyncMock(is_expired=False, url=URL('https://test.com'))
+    cache.request.return_value = response, CacheActions()
     session = CachedSession(cache=cache)
 
     await session.get('http://test.url')


### PR DESCRIPTION
Partial fix for #100. This does not yet fully handle cookies set within a redirect chain.