### PR TITLE
Only package Markdown and YAML files in sdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,8 @@ repository = "https://github.com/JWCook/aiohttp-client-cache"
 keywords = ["aiohttp", "async", "asyncio", "cache", "cache-backends", "client", "http",
             "persistence", "requests", "sqlite", "redis", "mongodb", "dynamodb"]
 include = [
-    { path = "*.md" },
-    { path = "*.yml" },
+    { path = "*.md", format = "sdist" },
+    { path = "*.yml", format = "sdist" },
     { path = "aiohttp_client_cache/py.typed" },
     { path = "docs", format = "sdist" },
     { path = "examples", format = "sdist" },


### PR DESCRIPTION
These end up getting installed if packaged in the (root of the) wheel.