### PR TITLE
Fix issue with restoring empty session cookies

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,7 +1,8 @@
 # History
 
-## 0.6.1 (Unreleased)
+## 0.6.1 (2022-02-13)
 * Migrate to aioredis 2.0
+* Fix issue with restoring empty session cookies
 
 ## 0.6.0 (2022-02-12)
 * Add a `bulk_delete()` method for all backends to improve performance of `delete_expired_responses()`

--- a/aiohttp_client_cache/response.py
+++ b/aiohttp_client_cache/response.py
@@ -61,7 +61,7 @@ class CachedResponse:
     _body: Any = attr.ib(default=b'')
     _content: StreamReader = attr.ib(default=None)
     _links: LinkItems = attr.ib(factory=list)
-    cookies: SimpleCookie = attr.ib(default=None)
+    cookies: SimpleCookie = attr.ib(factory=SimpleCookie)
     created_at: datetime = attr.ib(factory=datetime.utcnow)
     encoding: str = attr.ib(default='utf-8')
     expires: Optional[datetime] = attr.ib(default=None)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -33,7 +33,7 @@ HTTPDATE_DATETIME = datetime(2021, 4, 16, 21, 13)
 
 
 # Configure logging for pytest session
-basicConfig(level='INFO')
+basicConfig(level='ERROR')
 getLogger('aiohttp_client_cache').setLevel('DEBUG')
 
 

--- a/test/unit/test_session.py
+++ b/test/unit/test_session.py
@@ -112,3 +112,16 @@ async def test_session__cookies(mock_request):
     await session.get('http://test.url')
     cookies = session.cookie_jar.filter_cookies('https://test.com')
     assert cookies['test_cookie'].value == 'value'
+
+
+@patch.object(ClientSession, '_request')
+async def test_session__empty_cookies(mock_request):
+    """Previous versions didn't set cookies if they were empty. Just make sure it doesn't explode."""
+    cache = MagicMock(spec=CacheBackend)
+    response = AsyncMock(is_expired=False, url=URL('https://test.com'), cookies=None)
+    cache.request.return_value = response, CacheActions()
+    session = CachedSession(cache=cache)
+
+    session.cookie_jar.clear()
+    await session.get('http://test.url')
+    assert not session.cookie_jar.filter_cookies('https://test.com')


### PR DESCRIPTION
Fixes #110:

* Initializes `CachedResponse.cookies` to an empty dict if not present
* Handles case when `CachedResponse.cookies == None` on a previously cached response
    * **Note:** `aiohttp.abc.AbstractCookieJar.update_cookies()` does not handle `None`, and raises a `TypeError`