### PR TITLE
Fix get_urls() example

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -229,8 +229,8 @@ True 2021-01-01 18:00:00 2021-01-02 18:00:00 False
 ### Cache Contents
 You can use {py:meth}`.CachedSession.cache.get_urls` to see all URLs currently in the cache:
 ```python
->>> session = CachedSession(cache=SQLiteCache())
->>> print(session.cache.get_urls())
+>>> async for url in session.cache.get_urls():
+...     print(url)
 ['https://httpbin.org/get', 'https://httpbin.org/stream/100']
 ```
 

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -227,10 +227,10 @@ True 2021-01-01 18:00:00 2021-01-02 18:00:00 False
 ```
 
 ### Cache Contents
-You can use {py:meth}`.CachedSession.cache.urls` to see all URLs currently in the cache:
+You can use {py:meth}`.CachedSession.cache.get_urls` to see all URLs currently in the cache:
 ```python
 >>> session = CachedSession(cache=SQLiteCache())
->>> print(session.cache.urls)
+>>> print(session.cache.get_urls())
 ['https://httpbin.org/get', 'https://httpbin.org/stream/100']
 ```
 


### PR DESCRIPTION
'CacheBackend' object has no attribute 'urls'
API reference[1] clearly contradicts what was written in the user guide

[1] https://aiohttp-client-cache.readthedocs.io/en/latest/modules/aiohttp_client_cache.backends.base.html#aiohttp_client_cache.backends.base.CacheBackend.get_urls