### PR TITLE
Fix RedisCache import in docs

### DIFF
--- a/docs/backends.md
+++ b/docs/backends.md
@@ -19,7 +19,8 @@ Several cache backends are included, which can be selected using the `cache` par
 
 Usage example:
 ```python
->>> from aiohttp_client_cache import CachedSession, RedisCache
+>>> from aiohttp_client_cache import CachedSession
+>>> from aiohttp_client_cache.backends.redis import RedisCache
 >>>
 >>> async with CachedSession(cache=RedisCache()) as session:
 ...      await session.get('http://httpbin.org/get')


### PR DESCRIPTION
The previous example didn't work so I fixed it while I was at it, it used to return ImportError
```
ImportError: cannot import name 'RedisCache' from 'aiohttp_client_cache' (/usr/local/lib/python3.10/site-packages/aiohttp_client_cache/__init__.py)
```